### PR TITLE
Version 0.54.0

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,6 +1,6 @@
 FROM busybox:1.28 AS fetch-standard
 
-ARG VERSION=0.53
+ARG VERSION=0.54.0
 
 ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz /hugo.tar.gz
 RUN tar -zxvf hugo.tar.gz
@@ -10,7 +10,7 @@ RUN ["/hugo", "version"]
 
 FROM busybox:1.28 AS fetch-extended
 
-ARG VERSION=0.53
+ARG VERSION=0.54.0
 
 ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_extended_${VERSION}_Linux-64bit.tar.gz /hugo.tar.gz
 RUN tar -zxvf hugo.tar.gz

--- a/README.md
+++ b/README.md
@@ -11,32 +11,38 @@ These images sets `destination` during build and `bind` when started as server, 
 ## Available tags
 
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
-* Hugo 0.53: `0.53-busybox`, `busybox`, `0.53`, `latest`, `0.53-busybox-onbuild`, `0.53-onbuild`, `busybox-onbuild`, `onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/busybox/Dockerfile-busybox))
+* Hugo 0.54.0: `0.54.0-busybox`, `busybox`, `0.54.0`, `latest`, `0.54.0-busybox-onbuild`, `0.54.0-onbuild`, `busybox-onbuild`, `onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/busybox/Dockerfile-busybox)
+* Hugo 0.53: `0.53-busybox`, `0.53`, `0.53-busybox-onbuild`, `0.53-onbuild`, ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/busybox/Dockerfile-busybox))
 * Hugo 0.52: `0.52-busybox`, `0.52`, `0.52-busybox-onbuild`, `0.52-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/busybox/Dockerfile-busybox))
 * Hugo 0.51: `0.51-busybox`, `0.51`, `0.51-busybox-onbuild`, `0.51-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/busybox/Dockerfile-busybox))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
-* Hugo 0.53: `0.53-alpine`, `alpine`, `0.53-alpine-onbuild`, `alpine-onbuild`, `0.53-ext-alpine`, `ext-alpine`, `0.53-ext-alpine-onbuild`, `ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-alpine))
+* Hugo 0.54.0: `0.54.0-alpine`, `alpine`, `0.54.0-alpine-onbuild`, `alpine-onbuild`, `0.54.0-ext-alpine`, `ext-alpine`, `0.54.0-ext-alpine-onbuild`, `ext-alpine-onbuild`, `0.54.0-ext-nodejs`, `ext-nodejs` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-alpine))
+* Hugo 0.53: `0.53-alpine`, `0.53-alpine-onbuild`, `0.53-ext-alpine`, `0.53-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-alpine))
 * Hugo 0.52: `0.52-alpine`, `0.52-alpine-onbuild`, `0.52-ext-alpine`, `0.52-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-alpine))
 * Hugo 0.51: `0.51-alpine`, `0.51-alpine-onbuild`, `0.51-ext-alpine`, `0.51-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-alpine))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asciidoctor](http://asciidoctor.org/) installed:
-* Hugo 0.53: `0.53-asciidoctor`, `asciidoctor`, `0.53-asciidoctor-onbuild`, `asciidoctor-onbuild`, `0.53-ext-asciidoctor`, `ext-asciidoctor`, `0.53-ext-asciidoctor-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-asciidoctor))
+* Hugo 0.54.0: `0.54.0-asciidoctor`, `asciidoctor`, `0.54.0-asciidoctor-onbuild`, `asciidoctor-onbuild`, `0.54.0-ext-asciidoctor`, `ext-asciidoctor`, `0.54.0-ext-asciidoctor-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-asciidoctor))
+* Hugo 0.53: `0.53-asciidoctor`, `0.53-asciidoctor-onbuild`, `0.53-ext-asciidoctor`, `0.53-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-asciidoctor)
 * Hugo 0.52: `0.52-asciidoctor`, `0.52-asciidoctor-onbuild`, `0.52-ext-asciidoctor`, `0.52-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-asciidoctor))
 * Hugo 0.51: `0.51-asciidoctor`, `0.51-asciidoctor-onbuild`, `0.51-ext-asciidoctor`, `0.51-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-asciidoctor))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pandoc](https://pandoc.org/) installed:
-* Hugo 0.53: `0.53-pandoc`, `pandoc`, `0.53-pandoc-onbuild`, `pandoc-onbuild`, `0.53-ext-pandoc`, `ext-pandoc`, `0.53-ext-pandoc-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-pandoc))
+* Hugo 0.54.0: `0.54.0-pandoc`, `pandoc`, `0.54.0-pandoc-onbuild`, `pandoc-onbuild`, `0.54.0-ext-pandoc`, `ext-pandoc`, `0.54.0-ext-pandoc-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-pandoc)
+* Hugo 0.53: `0.53-pandoc`, `0.53-pandoc-onbuild`, `0.53-ext-pandoc`, `0.53-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-pandoc)
 * Hugo 0.52: `0.52-pandoc`, `0.52-pandoc-onbuild`, `0.52-ext-pandoc`, `0.52-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-pandoc))
 * Hugo 0.51: `0.51-pandoc`, `0.51-pandoc-onbuild`, `0.51-ext-pandoc`, `0.51-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-pandoc))
 
 Image based upon [Debian](https://hub.docker.com/r/_/debian/):
-* Hugo 0.53: `0.53-debian`, `debian`, `0.53-debian-onbuild`, `debian-onbuild`, `0.53-ext`, `ext`, `latest-ext`, `0.53-ext-debian`, `ext-debian`, `0.53-ext-debian-onbuild`, `ext-debian-onbuild`, `0.53-ext-onbuild`, `ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/debian/Dockerfile-debian))
+* Hugo 0.54.0: `0.54.0-debian`, `debian`, `0.54.0-debian-onbuild`, `debian-onbuild`, `0.54.0-ext`, `ext`, `latest-ext`, `0.54.0-ext-debian`, `ext-debian`, `0.54.0-ext-debian-onbuild`, `ext-debian-onbuild`, `0.54.0-ext-onbuild`, `ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/debian/Dockerfile-debian))
+* Hugo 0.53: `0.53-debian`, `0.53-debian-onbuild`, `0.53-ext`, `0.53-ext-debian`, `0.53-ext-debian-onbuild`, `0.53-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/debian/Dockerfile-debian)
 * Hugo 0.52: `0.52-debian`, `0.52-debian-onbuild`, `0.52-ext`, `0.52-ext-debian`, `0.52-ext-debian-onbuild`, `0.52-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/debian/Dockerfile-debian))
 * Hugo 0.51: `0.51-debian`, `0.51-debian-onbuild`, `0.51-ext`, `0.51-ext-debian`, `0.51-ext-debian-onbuild`, `0.51-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/debian/Dockerfile-debian))
 
 Image based upon [Ubuntu](https://hub.docker.com/r/_/ubuntu/):
-* Hugo 0.53: `0.53-ubuntu`, `ubuntu`, `0.53-ubuntu-onbuild`, `ubuntu-onbuild`, `0.53-ext-ubuntu`, `ext-ubuntu`, `0.53-ext-ubuntu-onbuild`, `ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/ubuntu/Dockerfile-ubuntu))
+* Hugo 0.54.0: `0.54.0-ubuntu`, `ubuntu`, `0.54.0-ubuntu-onbuild`, `ubuntu-onbuild`, `0.54.0-ext-ubuntu`, `ext-ubuntu`, `0.54.0-ext-ubuntu-onbuild`, `ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/ubuntu/Dockerfile-ubuntu))
+* Hugo 0.53: `0.53-ubuntu`, `0.53-ubuntu-onbuild`, `0.53-ext-ubuntu`, `0.53-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/ubuntu/Dockerfile-ubuntu)))
 * Hugo 0.52: `0.52-ubuntu`, `0.52-ubuntu-onbuild`, `0.52-ext-ubuntu`, `0.52-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/ubuntu/Dockerfile-ubuntu))
 * Hugo 0.51: `0.51-ubuntu`, `0.51-ubuntu-onbuild`, `0.51-ext-ubuntu`, `0.51-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/ubuntu/Dockerfile-ubuntu))
 
@@ -72,7 +78,7 @@ Normal build:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.53
+    image: klakegg/hugo:0.54.0
     volumes:
       - .:/src
       - ./output:/target
@@ -82,7 +88,7 @@ Run server:
 
 ```yaml
   server:
-    image: klakegg/hugo:0.53
+    image: klakegg/hugo:0.54.0
     command: server
     volumes:
       - .:/src
@@ -117,7 +123,7 @@ Table of Hugo extention features and the version when images first support the f
 | ------------- | ------ | ------- | ------ | ------ |
 | Hugo extended | 0.43   | -       | 0.43   | 0.43   |
 | PostCSS       | -      | -       | 0.43   | 0.43   |
-
+| NodeJS/Yarn   | 0.54.0 | -       | 0.54.0 | 0.54.0 |
 
 ## Using an ONBUILD image
 
@@ -126,7 +132,7 @@ The onbuild images adds content of the folder of your Dockerfile into `/src` and
 Example Dockerfile for your project where the site is made into an nginx image (Docker 17.05-ce or newer):
 
 ```Dockerfile
-FROM klakegg/hugo:0.53-onbuild AS hugo
+FROM klakegg/hugo:0.54.0-onbuild AS hugo
 
 FROM nginx
 COPY --from=hugo /onbuild /usr/share/nginx/html
@@ -155,14 +161,14 @@ Those wanting to override entrypoint in the image may easily do so.
 On command line using `--entrypoint`:
 
 ```
-docker run --rm -it -v $(pwd):/src -v $(pwd)/output:/src/public --entrypoint hugo klakegg/hugo:0.53
+docker run --rm -it -v $(pwd):/src -v $(pwd)/output:/src/public --entrypoint hugo klakegg/hugo:0.54.0
 ```
 
 In docker-compose using `entrypoint`:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.53
+    image: klakegg/hugo:0.54.0
     entrypoint: hugo
     volumes:
       - .:/src

--- a/dist/alpine/Dockerfile-ext-nodejs
+++ b/dist/alpine/Dockerfile-ext-nodejs
@@ -1,0 +1,41 @@
+FROM klakegg/hugo:base AS base
+
+FROM klakegg/hugo:base-certs as certs
+
+FROM klakegg/hugo:base-nodejs as node
+
+FROM ubuntu:18.04 AS ubuntu
+
+FROM scratch as image
+
+COPY files /files
+COPY --from=base /bin/hugo-extended /files/bin/hugo
+COPY --from=certs /etc/ssl/certs /files/etc/ssl/certs
+COPY --from=ubuntu /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25 /files/usr/lib/libstdc++.so.6
+COPY --from=node /node /files/
+CMD ln -s /files/node/bin/node /files/bin/node \
+    && ln -s /files/node/bin/npm /files/bin/npm \
+    && ln -s /files/node/bin/npx /files/bin/npx
+
+FROM frolvlad/alpine-glibc:alpine-3.8
+
+ENV HUGO_BIND="0.0.0.0" \
+    HUGO_DESTINATION="/target" \
+    HUGO_ENV="DEV"
+
+RUN apk add --no-cache libstdc++ busybox-suid bash bash-completion
+
+COPY --from=image /files /
+
+RUN ["node", "-v"]
+RUN npm install --global yarn
+
+RUN mkdir /etc/bash_completion.d \
+ && hugo gen autocomplete > /dev/null
+
+EXPOSE 1313
+
+VOLUME /src /target
+WORKDIR /src
+
+ENTRYPOINT ["sh", "/run.sh"]

--- a/dist/alpine/Step-build
+++ b/dist/alpine/Step-build
@@ -31,6 +31,10 @@ build "pandoc-onbuild" - \
 build "ext-alpine" - \
   "[version]-ext-alpine"
 
+# Alpine + Hugo extended + Nodejs
+build "ext-nodejs" - \
+  "[version]-ext-nodejs"
+
 # Alpine + Hugo extended + Onbuild
 template onbuild ext-alpine-onbuild ext-alpine
 build "ext-alpine-onbuild" - \

--- a/dist/alpine/Step-test
+++ b/dist/alpine/Step-test
@@ -4,6 +4,8 @@ test "alpine" "" "version" "Hugo"
 
 test "ext-alpine" "" "version" "Hugo"
 
+test "ext-nodejs" "--entrypoint node" "--version"
+
 test "asciidoctor" "--entrypoint asciidoctor" "--version" "Asciidoctor 1"
 
 test "pandoc" "--entrypoint pandoc-default" "--version" "Compiled with pandoc"

--- a/dist/debian/Dockerfile-ext-debian
+++ b/dist/debian/Dockerfile-ext-debian
@@ -19,9 +19,10 @@ COPY --from=image /files /
 
 RUN apt update \
  && apt install -y curl gnupg bash-completion \
- && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+ && curl -sL https://deb.nodesource.com/setup_11.x | bash - \
  && apt install -y nodejs \
  && npm install -g postcss-cli \
+ && npm install -g yarn \
  && apt remove -y curl gnupg apt-transport-https lsb-release \
  && apt autoremove -y \
  && rm -rf /var/lib/apt/lists/* \

--- a/dist/ubuntu/Dockerfile-ext-ubuntu
+++ b/dist/ubuntu/Dockerfile-ext-ubuntu
@@ -13,9 +13,10 @@ COPY files /
 
 RUN apt update \
  && apt install -y curl gnupg bash-completion \
- && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+ && curl -sL https://deb.nodesource.com/setup_11.x | bash - \
  && apt install -y nodejs \
  && npm install -g postcss-cli \
+ && npm install -g yarn \
  && apt remove -y curl gnupg apt-transport-https lsb-release \
  && apt autoremove -y \
  && rm -rf /var/lib/apt/lists/* \

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -1,7 +1,8 @@
 # All tags
 
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
-* Hugo 0.53: `0.53-busybox`, `busybox`, `0.53`, `latest`, `0.53-busybox-onbuild`, `0.53-onbuild`, `busybox-onbuild`, `onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/busybox/Dockerfile-busybox))
+* Hugo 0.54.0: `0.54.0-busybox`, `busybox`, `0.54.0`, `latest`, `0.54.0-busybox-onbuild`, `0.54.0-onbuild`, `busybox-onbuild`, `onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/busybox/Dockerfile-busybox)
+* Hugo 0.53: `0.53-busybox`, `0.53`, `0.53-busybox-onbuild`, `0.53-onbuild`, ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/busybox/Dockerfile-busybox))
 * Hugo 0.52: `0.52-busybox`, `0.52`, `0.52-busybox-onbuild`, `0.52-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/busybox/Dockerfile-busybox))
 * Hugo 0.51: `0.51-busybox`, `0.51`, `0.51-busybox-onbuild`, `0.51-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/busybox/Dockerfile-busybox))
 * Hugo 0.50: `0.50-busybox`, `0.50`, `0.50-busybox-onbuild`, `0.50-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/busybox/Dockerfile-busybox))
@@ -36,7 +37,8 @@ Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 * Hugo 0.34: `0.34-busybox`, `0.34` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.34/Dockerfile))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
-* Hugo 0.53: `0.53-alpine`, `alpine`, `0.53-alpine-onbuild`, `alpine-onbuild`, `0.53-ext-alpine`, `ext-alpine`, `0.53-ext-alpine-onbuild`, `ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-alpine))
+* Hugo 0.54.0: `0.54.0-alpine`, `alpine`, `0.54.0-alpine-onbuild`, `alpine-onbuild`, `0.54.0-ext-alpine`, `ext-alpine`, `0.54.0-ext-alpine-onbuild`, `ext-alpine-onbuild`, `0.54.0-ext-nodejs`, `ext-nodejs` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-alpine))
+* Hugo 0.53: `0.53-alpine`, `0.53-alpine-onbuild`, `0.53-ext-alpine`, `0.53-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-alpine))
 * Hugo 0.52: `0.52-alpine`, `0.52-alpine-onbuild`, `0.52-ext-alpine`, `0.52-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-alpine))
 * Hugo 0.51: `0.51-alpine`, `0.51-alpine-onbuild`, `0.51-ext-alpine`, `0.51-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-alpine))
 * Hugo 0.50: `0.50-alpine`, `0.50-alpine-onbuild`, `0.50-ext-alpine`, `0.50-ext-alpine-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/alpine/Dockerfile-alpine))
@@ -71,7 +73,8 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
 * Hugo 0.34: `0.34-alpine` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.34/Dockerfile-alpine))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asciidoctor](http://asciidoctor.org/) installed:
-* Hugo 0.53: `0.53-asciidoctor`, `asciidoctor`, `0.53-asciidoctor-onbuild`, `asciidoctor-onbuild`, `0.53-ext-asciidoctor`, `ext-asciidoctor`, `0.53-ext-asciidoctor-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-asciidoctor))
+* Hugo 0.54.0: `0.54.0-asciidoctor`, `asciidoctor`, `0.54.0-asciidoctor-onbuild`, `asciidoctor-onbuild`, `0.54.0-ext-asciidoctor`, `ext-asciidoctor`, `0.54.0-ext-asciidoctor-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-asciidoctor))
+* Hugo 0.53: `0.53-asciidoctor`, `0.53-asciidoctor-onbuild`, `0.53-ext-asciidoctor`, `0.53-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-asciidoctor))
 * Hugo 0.52: `0.52-asciidoctor`, `0.52-asciidoctor-onbuild`, `0.52-ext-asciidoctor`, `0.52-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-asciidoctor))
 * Hugo 0.51: `0.51-asciidoctor`, `0.51-asciidoctor-onbuild`, `0.51-ext-asciidoctor`, `0.51-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-asciidoctor))
 * Hugo 0.50: `0.50-asciidoctor`, `0.50-asciidoctor-onbuild`, `0.50-ext-asciidoctor`, `0.50-ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/alpine/Dockerfile-asciidoctor))
@@ -105,7 +108,8 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asci
 * Hugo 0.34: `0.34-asciidoctor` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.34/Dockerfile-asciidoctor))
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pandoc](https://pandoc.org/) installed:
-* Hugo 0.53: `0.53-pandoc`, `pandoc`, `0.53-pandoc-onbuild`, `pandoc-onbuild`, `0.53-ext-pandoc`, `ext-pandoc`, `0.53-ext-pandoc-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-pandoc))
+* Hugo 0.54.0: `0.54.0-pandoc`, `pandoc`, `0.54.0-pandoc-onbuild`, `pandoc-onbuild`, `0.54.0-ext-pandoc`, `ext-pandoc`, `0.54.0-ext-pandoc-onbuild`, `ext-asciidoctor-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/alpine/Dockerfile-pandoc)
+* Hugo 0.53: `0.53-pandoc`, `0.53-pandoc-onbuild`, `0.53-ext-pandoc`, `0.53-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/alpine/Dockerfile-pandoc))
 * Hugo 0.52: `0.52-pandoc`, `0.52-pandoc-onbuild`, `0.52-ext-pandoc`, `0.52-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/alpine/Dockerfile-pandoc))
 * Hugo 0.51: `0.51-pandoc`, `0.51-pandoc-onbuild`, `0.51-ext-pandoc`, `0.51-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/alpine/Dockerfile-pandoc))
 * Hugo 0.50: `0.50-pandoc`, `0.50-pandoc-onbuild`, `0.50-ext-pandoc`, `0.50-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/alpine/Dockerfile-pandoc))
@@ -121,7 +125,8 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pand
 * Hugo 0.44: `0.44-pandoc`, `0.44-pandoc-onbuild`, `0.44-ext-pandoc`, `0.44-ext-pandoc-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.44/dist/alpine/Dockerfile-pandoc))
 
 Image based upon [Debian](https://hub.docker.com/r/_/debian/):
-* Hugo 0.53: `0.53-debian`, `debian`, `0.53-debian-onbuild`, `debian-onbuild`, `0.53-ext`, `ext`, `latest-ext`, `0.53-ext-debian`, `ext-debian`, `0.53-ext-debian-onbuild`, `ext-debian-onbuild`, `0.53-ext-onbuild`, `ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/debian/Dockerfile-debian))
+* Hugo 0.54.0: `0.54.0-debian`, `debian`, `0.54.0-debian-onbuild`, `debian-onbuild`, `0.54.0-ext`, `ext`, `latest-ext`, `0.54.0-ext-debian`, `ext-debian`, `0.54.0-ext-debian-onbuild`, `ext-debian-onbuild`, `0.54.0-ext-onbuild`, `ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/debian/Dockerfile-debian))
+* Hugo 0.53: `0.53-debian`, `0.53-debian-onbuild`, `0.53-ext`, `0.53-ext-debian`, `0.53-ext-debian-onbuild`, `0.53-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.53/dist/debian/Dockerfile-debian))
 * Hugo 0.52: `0.52-debian`, `0.52-debian-onbuild`, `0.52-ext`, `0.52-ext-debian`, `0.52-ext-debian-onbuild`, `0.52-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/debian/Dockerfile-debian))
 * Hugo 0.51: `0.51-debian`, `0.51-debian-onbuild`, `0.51-ext`, `0.51-ext-debian`, `0.51-ext-debian-onbuild`, `0.51-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/debian/Dockerfile-debian))
 * Hugo 0.50: `0.50-debian`, `0.50-debian-onbuild`, `0.50-ext`, `0.50-ext-debian`, `0.50-ext-debian-onbuild`, `0.50-ext-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/debian/Dockerfile-debian))
@@ -138,7 +143,9 @@ Image based upon [Debian](https://hub.docker.com/r/_/debian/):
 * Hugo 0.43: `0.43-debian`, `0.43-debian-onbuild`, `0.43-ext-debian`, `0.43-ext-debian-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.43/debian/Dockerfile-debian))
 
 Image based upon [Ubuntu](https://hub.docker.com/r/_/ubuntu/):
-* Hugo 0.52: `0.52-ubuntu`, `ubuntu`, `0.52-ubuntu-onbuild`, `ubuntu-onbuild`, `0.52-ext-ubuntu`, `ext-ubuntu`, `0.52-ext-ubuntu-onbuild`, `ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/ubuntu/Dockerfile-ubuntu))
+* Hugo 0.54.0: `0.54.0-ubuntu`, `ubuntu`, `0.54.0-ubuntu-onbuild`, `ubuntu-onbuild`, `0.54.0-ext-ubuntu`, `ext-ubuntu`, `0.54.0-ext-ubuntu-onbuild`, `ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.54.0/dist/ubuntu/Dockerfile-ubuntu))
+* Hugo 0.53: `0.53-ubuntu`, `0.53-ubuntu-onbuild`, `0.53-ext-ubuntu`, `0.53-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/ubuntu/Dockerfile-ubuntu))
+* Hugo 0.52: `0.52-ubuntu`, `0.52-ubuntu-onbuild`, `0.52-ext-ubuntu`, `0.52-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.52/dist/ubuntu/Dockerfile-ubuntu))
 * Hugo 0.51: `0.51-ubuntu`, `0.51-ubuntu-onbuild`, `0.51-ext-ubuntu`, `0.51-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.51/dist/ubuntu/Dockerfile-ubuntu))
 * Hugo 0.50: `0.50-ubuntu`, `0.50-ubuntu-onbuild`, `0.50-ext-ubuntu`, `0.50-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.50/dist/ubuntu/Dockerfile-ubuntu))
 * Hugo 0.49.2: `0.49.2-ubuntu`, `0.49.2-ubuntu-onbuild`, `0.49.2-ext-ubuntu`, `0.49.2-ext-ubuntu-onbuild` ([Dockerfile](https://github.com/klakegg/docker-hugo/blob/0.49.2/dist/ubuntu/Dockerfile-ubuntu))

--- a/lib/base/Dockerfile-base-nodejs
+++ b/lib/base/Dockerfile-base-nodejs
@@ -1,0 +1,13 @@
+FROM busybox:1.28 AS fetch
+
+ARG NODE_VERSION=11.10.0
+ARG ARCH=x64
+
+ADD https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz /
+RUN mkdir /node
+RUN tar -xJf "node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" -C /node --strip-components=1 --no-same-owner
+RUN rm "node-v${NODE_VERSION}-linux-${ARCH}.tar.xz"
+
+FROM scratch
+
+COPY --from=fetch /node /node

--- a/lib/base/Step-build
+++ b/lib/base/Step-build
@@ -6,3 +6,4 @@ tag base "[version]-base"
 
 build_only base-certs
 build_only base-pandoc
+build_only base-nodejs


### PR DESCRIPTION
- Upgraded Hugo to latest, 0.54.0
- Added NodeJS compatibility to Alpine Docker image (ext-nodejs)
- Added Yarn to all ext images (Alpine - Ubuntu - Debian)
- Updated Documentation based on assumption that @klakegg will complete build and upload to Docker Hub

_Note: TravisCI configuration has not been modified and Hugo versioning has changed to 0.xx.0 as of Version 0.54.0_