### PR TITLE
Run checksum validations on Hugo binaries

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -2,8 +2,10 @@ FROM busybox:1.30 AS fetch-standard
 
 ARG VERSION=0.58.3
 
-ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz /hugo.tar.gz
-RUN tar -zxvf hugo.tar.gz
+ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz /
+ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_checksums.txt /
+RUN grep hugo_${VERSION}_Linux-64bit.tar.gz hugo_${VERSION}_checksums.txt | sha256sum -c
+RUN tar -zxvf hugo_${VERSION}_Linux-64bit.tar.gz
 RUN ["/hugo", "version"]
 RUN mkdir /etc/bash_completion.d  \
  && /hugo gen autocomplete > /dev/null
@@ -14,8 +16,10 @@ FROM busybox:1.30 AS fetch-extended
 
 ARG VERSION=0.58.3
 
-ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_extended_${VERSION}_Linux-64bit.tar.gz /hugo.tar.gz
-RUN tar -zxvf hugo.tar.gz
+ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_extended_${VERSION}_Linux-64bit.tar.gz /
+ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_checksums.txt /
+RUN grep hugo_extended_${VERSION}_Linux-64bit.tar.gz hugo_${VERSION}_checksums.txt | sha256sum -c
+RUN tar -zxvf hugo_extended_${VERSION}_Linux-64bit.tar.gz
 
 
 


### PR DESCRIPTION
Hello!

I've added a couple of lines into the base Dockerfile that downloads `hugo_[version]_checksums.txt` along with the binaries and runs `sha256sum` to compare them.

I always think this is a good thing to do if a checksum file is provided (which Hugo has done for a while). If the binary's corrupted/invalid for whatever reason, might as well catch it sooner than later. But I also really admire the simplicity of how you've set this up so I understand if this is too complex of an addition — I'm a better-safe-than-sorry person by nature! ;)

I ran the `travis` script locally and they all seemed to build fine — this shouldn't affect anything down the line (unless the .tar.gz file that Dockerfile-base downloads is invalid for some reason, of course).

Thanks! :)
