### PR TITLE
update onbuild template to bypass wrapper script

### DIFF
--- a/lib/template/Dockerfile-onbuild
+++ b/lib/template/Dockerfile-onbuild
@@ -1,4 +1,4 @@
 FROM [from]
 
 ONBUILD COPY . /src
-ONBUILD RUN hugo --destination=/onbuild
+ONBUILD RUN hugo-official --destination=/onbuild


### PR DESCRIPTION
the wrapper script is forcing a second --destination argument to be set
which results in no build being output.

fixes klakegg/docker-hugo#14