### PR TITLE
bump node 14.6.0 -> 16.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ In docker-compose using `entrypoint`:
 | Software | Version |
 | -------- | ------- |
 | Go       | 1.16.2  |
-| NodeJS   | 14.16.0 |
+| NodeJS   | 16.13.1 |
 | Pandoc   | 2.12    |
 | Yarn     | 1.22.10 |
 

--- a/src/files/_script/nodejs-glibc.sh
+++ b/src/files/_script/nodejs-glibc.sh
@@ -6,7 +6,7 @@ set -e
 set -u
 
 # Variables
-NODE_VERSION="14.16.0"
+NODE_VERSION="16.13.1"
 
 # Architecture
 TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}

--- a/src/files/_script/nodejs-musl.sh
+++ b/src/files/_script/nodejs-musl.sh
@@ -6,7 +6,7 @@ set -e
 set -u
 
 # Variables
-NODE_VERSION="14.16.0"
+NODE_VERSION="16.13.1"
 
 # Architecture
 TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}


### PR DESCRIPTION
Not actually sure if this works. I was able to run the Github action and it was able to successfully build the images, but it wasn't able to upload them which is likely a misconfiguration in my Github or Docker account. Also, I'm having trouble building them locally due to architecture differences (linux/amd64 v linux/arm64/v8), so I can't confirm 100%, but I think this is likely a good build.