### PR TITLE
Add Hugo v0.98.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,38 +11,38 @@ These images sets `bind` when started as server, otherwise no magic.
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 * Aliases: `latest`, `busybox`, `busybox-ci`, `ci`, `busybox-onbuild`, `onbuild`
 <!-- * Hugo NEXT: `NEXT-busybox`, `NEXT`, `NEXT-busybox-ci`, `NEXT-ci`, `NEXT-busybox-onbuild`, `NEXT-onbuild` -->
+* Hugo 0.98.0: `0.98.0-busybox`, `0.98.0`, `0.98.0-busybox-ci`, `0.98.0-ci`, `0.98.0-busybox-onbuild`, `0.98.0-onbuild`
 * Hugo 0.95.0: `0.95.0-busybox`, `0.95.0`, `0.95.0-busybox-ci`, `0.95.0-ci`, `0.95.0-busybox-onbuild`, `0.95.0-onbuild`
-* Hugo 0.94.2: `0.94.2-busybox`, `0.94.2`, `0.94.2-busybox-ci`, `0.94.2-ci`, `0.94.2-busybox-onbuild`, `0.94.2-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
 * Aliases: `alpine`, `alpine-ci`, `alpine-onbuild`, `ext-alpine`, `ext-alpine-ci`, `ext-alpine-onbuild`
 <!-- * Hugo NEXT: `NEXT-alpine`, `NEXT-alpine-ci`, `NEXT-alpine-onbuild`, `NEXT-ext-alpine`, `NEXT-ext-alpine-ci`, `NEXT-ext-alpine-onbuild` -->
+* Hugo 0.98.0: `0.98.0-alpine`, `0.98.0-alpine-ci`, `0.98.0-alpine-onbuild`, `0.98.0-ext-alpine`, `0.98.0-ext-alpine-ci`, `0.98.0-ext-alpine-onbuild`
 * Hugo 0.95.0: `0.95.0-alpine`, `0.95.0-alpine-ci`, `0.95.0-alpine-onbuild`, `0.95.0-ext-alpine`, `0.95.0-ext-alpine-ci`, `0.95.0-ext-alpine-onbuild`
-* Hugo 0.94.2: `0.94.2-alpine`, `0.94.2-alpine-ci`, `0.94.2-alpine-onbuild`, `0.94.2-ext-alpine`, `0.94.2-ext-alpine-ci`, `0.94.2-ext-alpine-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asciidoctor](http://asciidoctor.org/) installed:
 * Aliases: `asciidoctor`, `asciidoctor-ci`, `asciidoctor-onbuild`, `ext-asciidoctor`, `ext-asciidoctor-ci`, `ext-asciidoctor-onbuild`
 <!-- * Hugo NEXT: `NEXT-asciidoctor`, `NEXT-asciidoctor-onbuild`, `NEXT-asciidoctor-ci`, `NEXT-ext-asciidoctor`, `NEXT-ext-asciidoctor-ci`, `NEXT-ext-asciidoctor-onbuild` -->
+* Hugo 0.98.0: `0.98.0-asciidoctor`, `0.98.0-asciidoctor-onbuild`, `0.98.0-asciidoctor-ci`, `0.98.0-ext-asciidoctor`, `0.98.0-ext-asciidoctor-ci`, `0.98.0-ext-asciidoctor-onbuild`
 * Hugo 0.95.0: `0.95.0-asciidoctor`, `0.95.0-asciidoctor-onbuild`, `0.95.0-asciidoctor-ci`, `0.95.0-ext-asciidoctor`, `0.95.0-ext-asciidoctor-ci`, `0.95.0-ext-asciidoctor-onbuild`
-* Hugo 0.94.2: `0.94.2-asciidoctor`, `0.94.2-asciidoctor-onbuild`, `0.94.2-asciidoctor-ci`, `0.94.2-ext-asciidoctor`, `0.94.2-ext-asciidoctor-ci`, `0.94.2-ext-asciidoctor-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pandoc](https://pandoc.org/) installed:
 * Aliases: `pandoc`, `pandoc-ci`, `pandoc-onbuild`, `ext-pandoc`, `ext-pandoc-ci`, `ext-pandoc-onbuild`
 <!-- * Hugo NEXT: `NEXT-pandoc`, `NEXT-pandoc-ci`, `NEXT-pandoc-onbuild`, `NEXT-ext-pandoc`, `NEXT-ext-pandoc-ci`, `NEXT-ext-pandoc-onbuild` -->
+* Hugo 0.98.0: `0.98.0-pandoc`, `0.98.0-pandoc-ci`, `0.98.0-pandoc-onbuild`, `0.98.0-ext-pandoc`, `0.98.0-ext-pandoc-ci`, `0.98.0-ext-pandoc-onbuild`
 * Hugo 0.95.0: `0.95.0-pandoc`, `0.95.0-pandoc-ci`, `0.95.0-pandoc-onbuild`, `0.95.0-ext-pandoc`, `0.95.0-ext-pandoc-ci`, `0.95.0-ext-pandoc-onbuild`
-* Hugo 0.94.2: `0.94.2-pandoc`, `0.94.2-pandoc-ci`, `0.94.2-pandoc-onbuild`, `0.94.2-ext-pandoc`, `0.94.2-ext-pandoc-ci`, `0.94.2-ext-pandoc-onbuild`
 
 Image based upon [Debian](https://hub.docker.com/r/_/debian/):
 * Aliases: `debian`, `debian-ci`, `debian-onbuild`, `ext`, `latest-ext`, `ext-debian`, `ext-debian-ci`, `ext-ci`, `ext-debian-onbuild`, `ext-onbuild`
 <!-- * Hugo NEXT: `NEXT-debian`, `NEXT-debian-ci`, `NEXT-debian-onbuild`, `NEXT-ext`, `NEXT-ext-debian`, `NEXT-ext-debian-ci`, `NEXT-ext-ci`, `NEXT-ext-debian-onbuild`, `NEXT-ext-onbuild` -->
+* Hugo 0.98.0: `0.98.0-debian`, `0.98.0-debian-ci`, `0.98.0-debian-onbuild`, `0.98.0-ext`, `0.98.0-ext-debian`, `0.98.0-ext-debian-ci`, `0.98.0-ext-ci`, `0.98.0-ext-debian-onbuild`, `0.98.0-ext-onbuild`
 * Hugo 0.95.0: `0.95.0-debian`, `0.95.0-debian-ci`, `0.95.0-debian-onbuild`, `0.95.0-ext`, `0.95.0-ext-debian`, `0.95.0-ext-debian-ci`, `0.95.0-ext-ci`, `0.95.0-ext-debian-onbuild`, `0.95.0-ext-onbuild`
-* Hugo 0.94.2: `0.94.2-debian`, `0.94.2-debian-ci`, `0.94.2-debian-onbuild`, `0.94.2-ext`, `0.94.2-ext-debian`, `0.94.2-ext-debian-ci`, `0.94.2-ext-ci`, `0.94.2-ext-debian-onbuild`, `0.94.2-ext-onbuild`
 
 Image based upon [Ubuntu](https://hub.docker.com/r/_/ubuntu/):
 * Aliases: `ubuntu`, `ubuntu-ci`, `ubuntu-onbuild`, `ext-ubuntu`, `ext-ubuntu-ci`, `ext-ubuntu-onbuild`
 <!-- * Hugo NEXT: `NEXT-ubuntu`, `NEXT-ubuntu-ci`, `NEXT-ubuntu-onbuild`, `NEXT-ext-ubuntu`, `NEXT-ext-ubuntu-ci`, `NEXT-ext-ubuntu-onbuild` -->
+* Hugo 0.98.0: `0.98.0-ubuntu`, `0.98.0-ubuntu-ci`, `0.98.0-ubuntu-onbuild`, `0.98.0-ext-ubuntu`, `0.98.0-ext-ubuntu-ci`, `0.98.0-ext-ubuntu-onbuild`
 * Hugo 0.95.0: `0.95.0-ubuntu`, `0.95.0-ubuntu-ci`, `0.95.0-ubuntu-onbuild`, `0.95.0-ext-ubuntu`, `0.95.0-ext-ubuntu-ci`, `0.95.0-ext-ubuntu-onbuild`
-* Hugo 0.94.2: `0.94.2-ubuntu`, `0.94.2-ubuntu-ci`, `0.94.2-ubuntu-onbuild`, `0.94.2-ext-ubuntu`, `0.94.2-ext-ubuntu-ci`, `0.94.2-ext-ubuntu-onbuild`
 
 *Looking for older tags? Please see the [complete list of tags](https://github.com/klakegg/docker-hugo/blob/master/doc/tags.md).*
 
@@ -60,7 +60,7 @@ Normal build:
 ```shell
 docker run --rm -it \
   -v $(pwd):/src \
-  klakegg/hugo:0.95.0
+  klakegg/hugo:0.98.0
 ```
 
 Run server:
@@ -69,7 +69,7 @@ Run server:
 docker run --rm -it \
   -v $(pwd):/src \
   -p 1313:1313 \
-  klakegg/hugo:0.95.0 \
+  klakegg/hugo:0.98.0 \
   server
 ```
 
@@ -80,7 +80,7 @@ Normal build:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.95.0
+    image: klakegg/hugo:0.98.0
     volumes:
       - ".:/src"
 ```
@@ -89,7 +89,7 @@ Run server:
 
 ```yaml
   server:
-    image: klakegg/hugo:0.95.0
+    image: klakegg/hugo:0.98.0
     command: server
     volumes:
       - ".:/src"
@@ -136,7 +136,7 @@ services:
 script:
 - docker run --rm -i \
     -v $(pwd):/src \
-    klakegg/hugo:0.95.0
+    klakegg/hugo:0.98.0
 ```
 
 The `bash` environment is used for faster loading before Travis is ready to trigger Docker.
@@ -152,7 +152,7 @@ To get into a shell for your site:
 ```shell
 docker run --rm -it \
   -v $(pwd):/src \
-  klakegg/hugo:0.95.0-alpine \
+  klakegg/hugo:0.98.0-alpine \
   shell
 ```
 
@@ -185,7 +185,7 @@ The onbuild images adds content of the folder of your Dockerfile into `/src` and
 Example Dockerfile for your project where the site is made into an nginx image (Docker 17.05-ce or newer):
 
 ```Dockerfile
-FROM klakegg/hugo:0.95.0-onbuild AS hugo
+FROM klakegg/hugo:0.98.0-onbuild AS hugo
 
 FROM nginx
 COPY --from=hugo /target /usr/share/nginx/html
@@ -222,7 +222,7 @@ Example of explicit setting `pandoc` alias:
 docker run --rm -it \
   -v $(pwd):/src \
   -e HUGO_PANDOC="pandoc-default --strip-empty-paragraphs" \
-  klakegg/hugo:0.95.0-pandoc
+  klakegg/hugo:0.98.0-pandoc
 ```
 
 
@@ -238,14 +238,14 @@ On command line using `--entrypoint`:
 docker run --rm -it \
   -v $(pwd):/src \
   --entrypoint hugo-official \
-  klakegg/hugo:0.95.0
+  klakegg/hugo:0.98.0
 ```
 
 In docker-compose using `entrypoint`:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.95.0
+    image: klakegg/hugo:0.98.0
     entrypoint: hugo-official
     volumes:
       - ".:/src"

--- a/doc/changelog/0.98.0
+++ b/doc/changelog/0.98.0
@@ -1,0 +1,48 @@
+## :heartbeat: Updates
+
+* Hugo: [`0.98.0`](https://github.com/klakegg/docker-hugo/releases/tag/0.98.0) => `0.98.0`
+
+
+## Docker images
+
+<details>
+<summary>Click to see available images</summary>
+
+This release is available from Docker Hub as project `klakegg/hugo` with the following tags:
+
+| Alias tags                   | Version specific tags                      |
+| ---------------------------- | ------------------------------------------ |
+| `busybox`, `latest`          | `0.98.0-busybox`, `0.98.0`                     |
+| `busybox-ci`, `ci`           | `0.98.0-busybox-ci`, `0.98.0-ci`               |
+| `busybox-onbuild`, `onbuild` | `0.98.0-busybox-onbuild`, `0.98.0-onbuild`     |
+| `alpine`                     | `0.98.0-alpine`                              |
+| `alpine-ci`                  | `0.98.0-alpine-ci`                           |
+| `alpine-onbuild`             | `0.98.0-alpine-onbuild`                      |
+| `asciidoctor`                | `0.98.0-asciidoctor`                         |
+| `asciidoctor-ci`             | `0.98.0-asciidoctor-ci`                      |
+| `asciidoctor-onbuild`        | `0.98.0-asciidoctor-onbuild`                 |
+| `pandoc`                     | `0.98.0-pandoc`                              |
+| `pandoc-ci`                  | `0.98.0-pandoc-ci`                           |
+| `pandoc-onbuild`             | `0.98.0-pandoc-onbuild`                      |
+| `ext-alpine`                 | `0.98.0-ext-alpine`                          |
+| `ext-alpine-ci`              | `0.98.0-ext-alpine-ci`                       |
+| `ext-alpine-onbuild`         | `0.98.0-ext-alpine-onbuild`                  |
+| `ext-asciidoctor`            | `0.98.0-ext-asciidoctor`                     |
+| `ext-asciidoctor-ci`         | `0.98.0-ext-asciidoctor-ci`                  |
+| `ext-asciidoctor-onbuild`    | `0.98.0-ext-asciidoctor-onbuild`             |
+| `ext-pandoc`                 | `0.98.0-ext-pandoc`                          |
+| `ext-pandoc-ci`              | `0.98.0-ext-pandoc-ci`                       |
+| `ext-pandoc-onbuild`         | `0.98.0-ext-pandoc-onbuild`                  |
+| `debian`                     | `0.98.0-debian`                              |
+| `debian-ci`                  | `0.98.0-debian-ci`                           |
+| `debian-onbuild`             | `0.98.0-debian-onbuild`                      |
+| `ext-debian`, `ext`, `latest-ext` | `0.98.0-ext-debian`, `0.98.0-ext`         |
+| `ext-debian-ci`, `ext-ci`    | `0.98.0-ext-debian-ci`, `0.98.0-ext-ci`        |
+| `ext-debian-onbuild`, `ext-onbuild` | `0.98.0-ext-debian-onbuild`, `0.98.0-ext-onbuild` |
+| `ubuntu`                     | `0.98.0-ubuntu`                            |
+| `ubuntu-ci`                  | `0.98.0-ubuntu-ci`                         |
+| `ubuntu-onbuild`             | `0.98.0-ubuntu-onbuild`                    |
+| `ext-ubuntu`                 | `0.98.0-ext-ubuntu`                        |
+| `ext-ubuntu-ci`              | `0.98.0-ext-ubuntu-ci`                     |
+| `ext-ubuntu-onbuild`         | `0.98.0-ext-ubuntu-onbuild`                |
+</details>

--- a/doc/changelog/NEXT.md
+++ b/doc/changelog/NEXT.md
@@ -15,7 +15,7 @@
 
 ## :heartbeat: Updates
 
-* Hugo: [`0.95.0`](https://github.com/klakegg/docker-hugo/releases/tag/0.95.0) => `NEXT`
+* Hugo: [`0.98.0`](https://github.com/klakegg/docker-hugo/releases/tag/0.98.0) => `NEXT`
 
 
 ## Docker images

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -3,6 +3,7 @@
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 * Aliases: `latest`, `busybox`, `busybox-ci`, `ci`, `busybox-onbuild`, `onbuild`
 <!-- * Hugo NEXT: `NEXT-busybox`, `NEXT`, `NEXT-busybox-ci`, `NEXT-ci`, `NEXT-busybox-onbuild`, `NEXT-onbuild` -->
+* Hugo 0.98.0: `0.98.0-busybox`, `0.98.0`, `0.98.0-busybox-ci`, `0.98.0-ci`, `0.98.0-busybox-onbuild`, `0.98.0-onbuild`
 * Hugo 0.95.0: `0.95.0-busybox`, `0.95.0`, `0.95.0-busybox-ci`, `0.95.0-ci`, `0.95.0-busybox-onbuild`, `0.95.0-onbuild`
 * Hugo 0.94.2: `0.94.2-busybox`, `0.94.2`, `0.94.2-busybox-ci`, `0.94.2-ci`, `0.94.2-busybox-onbuild`, `0.94.2-onbuild`
 * Hugo 0.94.1: `0.94.1-busybox`, `0.94.1`, `0.94.1-busybox-ci`, `0.94.1-ci`, `0.94.1-busybox-onbuild`, `0.94.1-onbuild`

--- a/src/project.yaml
+++ b/src/project.yaml
@@ -1,5 +1,5 @@
 image: klakegg/hugo
-version: 0.95.0
+version: 0.98.0
 
 platforms:
   - linux/amd64


### PR DESCRIPTION
Following the changes in c23089428829dc77ce846687b312625cc1a9e725, add
support for the latest version of Hugo, 0.98.0.
