### PR TITLE
Updated node.js version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ In docker-compose using `entrypoint`:
 | Software | Version |
 | -------- | ------- |
 | Go       | 1.16.2  |
-| NodeJS   | 16.x    |
+| NodeJS   | 18.x    |
 | Pandoc   | 2.12    |
 | Yarn     | 1.22.10 |
 


### PR DESCRIPTION
Fixes #68 

The actual version of Node that is installed is 18.x, verified from the following locations:

- https://github.com/klakegg/docker-hugo/blob/master/src/files/_script/nodejs-glibc.sh#L9
- https://github.com/klakegg/docker-hugo/blob/master/src/docker/debian-ext/Dockerfile#L32
- https://github.com/klakegg/docker-hugo/blob/master/src/docker/ubuntu-ext/Dockerfile#L32

This unfortunately broke one of my CI builds due to https://github.com/webpack/webpack/issues/14532 - once I realised the problem it's an easy fix fortunately.