### PR TITLE
Add /src dir to git safe.directories for ext images

### DIFF
--- a/src/docker/alpine-ext/ext-alpine.df
+++ b/src/docker/alpine-ext/ext-alpine.df
@@ -42,7 +42,10 @@ RUN true \
  #
  # Prepare folders
  && mkdir -p /src /target \
- && chmod a+w /src /target
+ && chmod a+w /src /target \
+ #
+ # add /src to safe.directory
+ && git config --global --add safe.directory /src
 
 EXPOSE 1313
 

--- a/src/docker/debian-ext/Dockerfile
+++ b/src/docker/debian-ext/Dockerfile
@@ -43,7 +43,10 @@ RUN true \
  && rm -rf /var/lib/apt/lists/* \
  && find /tmp -mindepth 1 -maxdepth 1 | xargs rm -rf \
  && mkdir -p /src /target \
- && chmod a+w /src /target
+ && chmod a+w /src /target \
+ #
+ # add /src to safe.directory
+ && git config --global --add safe.directory /src
 
 COPY --from=base--golang / /
 

--- a/src/docker/ubuntu-ext/Dockerfile
+++ b/src/docker/ubuntu-ext/Dockerfile
@@ -43,7 +43,10 @@ RUN true \
  && rm -rf /var/lib/apt/lists/* \
  && find /tmp -mindepth 1 -maxdepth 1 | xargs rm -rf \
  && mkdir -p /src /target \
- && chmod a+w /src /target
+ && chmod a+w /src /target \
+ #
+ # add /src to safe.directory
+ && git config --global --add safe.directory /src
 
 COPY --from=base--golang / /
 


### PR DESCRIPTION
When using the ext images to build hugo pages from mounted source using docker volumes, the hugo build fails while reading git info (eg. for infos like: This page was last modified: date - commit)

This PR fixes #71 