### PR TITLE
Version 0.111.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,27 @@ These images sets `bind` when started as server, otherwise no magic.
 
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 * Aliases: `latest`, `busybox`, `busybox-ci`, `ci`, `busybox-onbuild`, `onbuild`
-* Hugo 0.107.0: `0.107.0-busybox`, `0.107.0`, `0.107.0-busybox-ci`, `0.107.0-ci`, `0.107.0-busybox-onbuild`, `0.107.0-onbuild`
+* Hugo 0.111.3: `0.111.3-busybox`, `0.111.3`, `0.111.3-busybox-ci`, `0.111.3-ci`, `0.111.3-busybox-onbuild`, `0.111.3-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
 * Aliases: `alpine`, `alpine-ci`, `alpine-onbuild`, `ext-alpine`, `ext-alpine-ci`, `ext-alpine-onbuild`
-* Hugo 0.107.0: `0.107.0-alpine`, `0.107.0-alpine-ci`, `0.107.0-alpine-onbuild`, `0.107.0-ext-alpine`, `0.107.0-ext-alpine-ci`, `0.107.0-ext-alpine-onbuild`
+* Hugo 0.111.3: `0.111.3-alpine`, `0.111.3-alpine-ci`, `0.111.3-alpine-onbuild`, `0.111.3-ext-alpine`, `0.111.3-ext-alpine-ci`, `0.111.3-ext-alpine-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asciidoctor](http://asciidoctor.org/) installed:
 * Aliases: `asciidoctor`, `asciidoctor-ci`, `asciidoctor-onbuild`, `ext-asciidoctor`, `ext-asciidoctor-ci`, `ext-asciidoctor-onbuild`
-* Hugo 0.107.0: `0.107.0-asciidoctor`, `0.107.0-asciidoctor-onbuild`, `0.107.0-asciidoctor-ci`, `0.107.0-ext-asciidoctor`, `0.107.0-ext-asciidoctor-ci`, `0.107.0-ext-asciidoctor-onbuild`
+* Hugo 0.111.3: `0.111.3-asciidoctor`, `0.111.3-asciidoctor-onbuild`, `0.111.3-asciidoctor-ci`, `0.111.3-ext-asciidoctor`, `0.111.3-ext-asciidoctor-ci`, `0.111.3-ext-asciidoctor-onbuild`
 
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pandoc](https://pandoc.org/) installed:
 * Aliases: `pandoc`, `pandoc-ci`, `pandoc-onbuild`, `ext-pandoc`, `ext-pandoc-ci`, `ext-pandoc-onbuild`
-* Hugo 0.107.0: `0.107.0-pandoc`, `0.107.0-pandoc-ci`, `0.107.0-pandoc-onbuild`, `0.107.0-ext-pandoc`, `0.107.0-ext-pandoc-ci`, `0.107.0-ext-pandoc-onbuild`
+* Hugo 0.111.3: `0.111.3-pandoc`, `0.111.3-pandoc-ci`, `0.111.3-pandoc-onbuild`, `0.111.3-ext-pandoc`, `0.111.3-ext-pandoc-ci`, `0.111.3-ext-pandoc-onbuild`
 
 Image based upon [Debian](https://hub.docker.com/r/_/debian/):
 * Aliases: `debian`, `debian-ci`, `debian-onbuild`, `ext`, `latest-ext`, `ext-debian`, `ext-debian-ci`, `ext-ci`, `ext-debian-onbuild`, `ext-onbuild`
-* Hugo 0.107.0: `0.107.0-debian`, `0.107.0-debian-ci`, `0.107.0-debian-onbuild`, `0.107.0-ext`, `0.107.0-ext-debian`, `0.107.0-ext-debian-ci`, `0.107.0-ext-ci`,`0.107.0-ext-debian-onbuild`, `0.107.0-ext-onbuild`
+* Hugo 0.111.3: `0.111.3-debian`, `0.111.3-debian-ci`, `0.111.3-debian-onbuild`, `0.111.3-ext`, `0.111.3-ext-debian`, `0.111.3-ext-debian-ci`, `0.111.3-ext-ci`,`0.111.3-ext-debian-onbuild`, `0.111.3-ext-onbuild`
 
 Image based upon [Ubuntu](https://hub.docker.com/r/_/ubuntu/):
 * Aliases: `ubuntu`, `ubuntu-ci`, `ubuntu-onbuild`, `ext-ubuntu`, `ext-ubuntu-ci`, `ext-ubuntu-onbuild`
-* Hugo 0.107.0: `0.107.0-ubuntu`, `0.107.0-ubuntu-ci`, `0.107.0-ubuntu-onbuild`, `0.107.0-ext-ubuntu`, `0.107.0-ext-ubuntu-ci`, `0.107.0-ext-ubuntu-onbuild`
+* Hugo 0.111.3: `0.111.3-ubuntu`, `0.111.3-ubuntu-ci`, `0.111.3-ubuntu-onbuild`, `0.111.3-ext-ubuntu`, `0.111.3-ext-ubuntu-ci`, `0.111.3-ext-ubuntu-onbuild`
 
 *Looking for older tags? Please see the [complete list of tags](https://github.com/klakegg/docker-hugo/blob/master/doc/tags.md).*
 
@@ -48,7 +48,7 @@ Normal build:
 ```shell
 docker run --rm -it \
   -v $(pwd):/src \
-  klakegg/hugo:0.107.0
+  klakegg/hugo:0.111.3
 ```
 
 Run server:
@@ -57,7 +57,7 @@ Run server:
 docker run --rm -it \
   -v $(pwd):/src \
   -p 1313:1313 \
-  klakegg/hugo:0.107.0 \
+  klakegg/hugo:0.111.3 \
   server
 ```
 
@@ -68,7 +68,7 @@ Normal build:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.107.0
+    image: klakegg/hugo:0.111.3
     volumes:
       - ".:/src"
 ```
@@ -77,7 +77,7 @@ Run server:
 
 ```yaml
   server:
-    image: klakegg/hugo:0.107.0
+    image: klakegg/hugo:0.111.3
     command: server
     volumes:
       - ".:/src"
@@ -124,7 +124,7 @@ services:
 script:
 - docker run --rm -i \
     -v $(pwd):/src \
-    klakegg/hugo:0.107.0
+    klakegg/hugo:0.111.3
 ```
 
 The `bash` environment is used for faster loading before Travis is ready to trigger Docker.
@@ -140,7 +140,7 @@ To get into a shell for your site:
 ```shell
 docker run --rm -it \
   -v $(pwd):/src \
-  klakegg/hugo:0.107.0-alpine \
+  klakegg/hugo:0.111.3-alpine \
   shell
 ```
 
@@ -173,7 +173,7 @@ The onbuild images adds content of the folder of your Dockerfile into `/src` and
 Example Dockerfile for your project where the site is made into an nginx image (Docker 17.05-ce or newer):
 
 ```Dockerfile
-FROM klakegg/hugo:0.107.0-onbuild AS hugo
+FROM klakegg/hugo:0.111.3-onbuild AS hugo
 
 FROM nginx
 COPY --from=hugo /target /usr/share/nginx/html
@@ -210,7 +210,7 @@ Example of explicit setting `pandoc` alias:
 docker run --rm -it \
   -v $(pwd):/src \
   -e HUGO_PANDOC="pandoc-default --strip-empty-paragraphs" \
-  klakegg/hugo:0.107.0-pandoc
+  klakegg/hugo:0.111.3-pandoc
 ```
 
 
@@ -226,14 +226,14 @@ On command line using `--entrypoint`:
 docker run --rm -it \
   -v $(pwd):/src \
   --entrypoint hugo-official \
-  klakegg/hugo:0.107.0
+  klakegg/hugo:0.111.3
 ```
 
 In docker-compose using `entrypoint`:
 
 ```yaml
   build:
-    image: klakegg/hugo:0.107.0
+    image: klakegg/hugo:0.111.3
     entrypoint: hugo-official
     volumes:
       - ".:/src"

--- a/doc/changelog/0.111.3.md
+++ b/doc/changelog/0.111.3.md
@@ -1,0 +1,48 @@
+## :heartbeat: Updates
+
+* Hugo: [`0.107.0`](https://github.com/klakegg/docker-hugo/releases/tag/0.107.0) => `0.111.3`
+
+
+## Docker images
+
+<details>
+<summary>Click to see available images</summary>
+
+This release is available from Docker Hub as project `klakegg/hugo` with the following tags:
+
+| Alias tags                   | Version specific tags                      |
+| ---------------------------- | ------------------------------------------ |
+| `busybox`, `latest`          | `0.111.3-busybox`, `0.111.3`                     |
+| `busybox-ci`, `ci`           | `0.111.3-busybox-ci`, `0.111.3-ci`               |
+| `busybox-onbuild`, `onbuild` | `0.111.3-busybox-onbuild`, `0.111.3-onbuild`     |
+| `alpine`                     | `0.111.3-alpine`                              |
+| `alpine-ci`                  | `0.111.3-alpine-ci`                           |
+| `alpine-onbuild`             | `0.111.3-alpine-onbuild`                      |
+| `asciidoctor`                | `0.111.3-asciidoctor`                         |
+| `asciidoctor-ci`             | `0.111.3-asciidoctor-ci`                      |
+| `asciidoctor-onbuild`        | `0.111.3-asciidoctor-onbuild`                 |
+| `pandoc`                     | `0.111.3-pandoc`                              |
+| `pandoc-ci`                  | `0.111.3-pandoc-ci`                           |
+| `pandoc-onbuild`             | `0.111.3-pandoc-onbuild`                      |
+| `ext-alpine`                 | `0.111.3-ext-alpine`                          |
+| `ext-alpine-ci`              | `0.111.3-ext-alpine-ci`                       |
+| `ext-alpine-onbuild`         | `0.111.3-ext-alpine-onbuild`                  |
+| `ext-asciidoctor`            | `0.111.3-ext-asciidoctor`                     |
+| `ext-asciidoctor-ci`         | `0.111.3-ext-asciidoctor-ci`                  |
+| `ext-asciidoctor-onbuild`    | `0.111.3-ext-asciidoctor-onbuild`             |
+| `ext-pandoc`                 | `0.111.3-ext-pandoc`                          |
+| `ext-pandoc-ci`              | `0.111.3-ext-pandoc-ci`                       |
+| `ext-pandoc-onbuild`         | `0.111.3-ext-pandoc-onbuild`                  |
+| `debian`                     | `0.111.3-debian`                              |
+| `debian-ci`                  | `0.111.3-debian-ci`                           |
+| `debian-onbuild`             | `0.111.3-debian-onbuild`                      |
+| `ext-debian`, `ext`, `latest-ext` | `0.111.3-ext-debian`, `0.111.3-ext`         |
+| `ext-debian-ci`, `ext-ci`    | `0.111.3-ext-debian-ci`, `0.111.3-ext-ci`        |
+| `ext-debian-onbuild`, `ext-onbuild` | `0.111.3-ext-debian-onbuild`, `0.111.3-ext-onbuild` |
+| `ubuntu`                     | `0.111.3-ubuntu`                            |
+| `ubuntu-ci`                  | `0.111.3-ubuntu-ci`                         |
+| `ubuntu-onbuild`             | `0.111.3-ubuntu-onbuild`                    |
+| `ext-ubuntu`                 | `0.111.3-ext-ubuntu`                        |
+| `ext-ubuntu-ci`              | `0.111.3-ext-ubuntu-ci`                     |
+| `ext-ubuntu-onbuild`         | `0.111.3-ext-ubuntu-onbuild`                |
+</details>

--- a/doc/changelog/NEXT.md
+++ b/doc/changelog/NEXT.md
@@ -15,7 +15,7 @@
 
 ## :heartbeat: Updates
 
-* Hugo: [`0.107.0`](https://github.com/klakegg/docker-hugo/releases/tag/0.107.0) => `NEXT`
+* Hugo: [`0.111.3`](https://github.com/klakegg/docker-hugo/releases/tag/0.111.3) => `NEXT`
 
 
 ## Docker images

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -3,6 +3,7 @@
 Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 * Aliases: `latest`, `busybox`, `busybox-ci`, `ci`, `busybox-onbuild`, `onbuild`
 <!-- * Hugo NEXT: `NEXT-busybox`, `NEXT`, `NEXT-busybox-ci`, `NEXT-ci`, `NEXT-busybox-onbuild`, `NEXT-onbuild` -->
+* Hugo 0.111.3: `0.111.3-busybox`, `0.111.3`, `0.111.3-busybox-ci`, `0.111.3-ci`, `0.111.3-busybox-onbuild`, `0.111.3-onbuild`
 * Hugo 0.107.0: `0.107.0-busybox`, `0.107.0`, `0.107.0-busybox-ci`, `0.107.0-ci`, `0.107.0-busybox-onbuild`, `0.107.0-onbuild`
 * Hugo 0.106.0: `0.106.0-busybox`, `0.106.0`, `0.106.0-busybox-ci`, `0.106.0-ci`, `0.106.0-busybox-onbuild`, `0.106.0-onbuild`
 * Hugo 0.105.0: `0.105.0-busybox`, `0.105.0`, `0.105.0-busybox-ci`, `0.105.0-ci`, `0.105.0-busybox-onbuild`, `0.105.0-onbuild`
@@ -171,6 +172,7 @@ Default minimal image based upon [Busybox](https://hub.docker.com/r/_/busybox/):
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
 * Aliases: `alpine`, `alpine-ci`, `alpine-onbuild`, `ext-alpine`, `ext-alpine-ci`, `ext-alpine-onbuild`
 <!-- * Hugo NEXT: `NEXT-alpine`, `NEXT-alpine-ci`, `NEXT-alpine-onbuild`, `NEXT-ext-alpine`, `NEXT-ext-alpine-ci`, `NEXT-ext-alpine-onbuild` -->
+* Hugo 0.111.3: `0.111.3-alpine`, `0.111.3-alpine-ci`, `0.111.3-alpine-onbuild`, `0.111.3-ext-alpine`, `0.111.3-ext-alpine-ci`, `0.111.3-ext-alpine-onbuild`
 * Hugo 0.107.0: `0.107.0-alpine`, `0.107.0-alpine-ci`, `0.107.0-alpine-onbuild`, `0.107.0-ext-alpine`, `0.107.0-ext-alpine-ci`, `0.107.0-ext-alpine-onbuild`
 * Hugo 0.106.0: `0.106.0-alpine`, `0.106.0-alpine-ci`, `0.106.0-alpine-onbuild`, `0.106.0-ext-alpine`, `0.106.0-ext-alpine-ci`, `0.106.0-ext-alpine-onbuild`
 * Hugo 0.105.0: `0.105.0-alpine`, `0.105.0-alpine-ci`, `0.105.0-alpine-onbuild`, `0.105.0-ext-alpine`, `0.105.0-ext-alpine-ci`, `0.105.0-ext-alpine-onbuild`
@@ -339,6 +341,7 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/):
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asciidoctor](http://asciidoctor.org/) installed:
 * Aliases: `asciidoctor`, `asciidoctor-ci`, `asciidoctor-onbuild`, `ext-asciidoctor`, `ext-asciidoctor-ci`, `ext-asciidoctor-onbuild`
 <!-- * Hugo NEXT: `NEXT-asciidoctor`, `NEXT-asciidoctor-onbuild`, `NEXT-asciidoctor-ci`, `NEXT-ext-asciidoctor`, `NEXT-ext-asciidoctor-ci`, `NEXT-ext-asciidoctor-onbuild` -->
+* Hugo 0.111.3: `0.111.3-asciidoctor`, `0.111.3-asciidoctor-onbuild`, `0.111.3-asciidoctor-ci`, `0.111.3-ext-asciidoctor`, `0.111.3-ext-asciidoctor-ci`, `0.111.3-ext-asciidoctor-onbuild`
 * Hugo 0.107.0: `0.107.0-asciidoctor`, `0.107.0-asciidoctor-onbuild`, `0.107.0-asciidoctor-ci`, `0.107.0-ext-asciidoctor`, `0.107.0-ext-asciidoctor-ci`, `0.107.0-ext-asciidoctor-onbuild`
 * Hugo 0.106.0: `0.106.0-asciidoctor`, `0.106.0-asciidoctor-onbuild`, `0.106.0-asciidoctor-ci`, `0.106.0-ext-asciidoctor`, `0.106.0-ext-asciidoctor-ci`, `0.106.0-ext-asciidoctor-onbuild`
 * Hugo 0.105.0: `0.105.0-asciidoctor`, `0.105.0-asciidoctor-onbuild`, `0.105.0-asciidoctor-ci`, `0.105.0-ext-asciidoctor`, `0.105.0-ext-asciidoctor-ci`, `0.105.0-ext-asciidoctor-onbuild`
@@ -506,6 +509,7 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Asci
 Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pandoc](https://pandoc.org/) installed:
 * Aliases: `pandoc`, `pandoc-ci`, `pandoc-onbuild`, `ext-pandoc`, `ext-pandoc-ci`, `ext-pandoc-onbuild`
 <!-- * Hugo NEXT: `NEXT-pandoc`, `NEXT-pandoc-ci`, `NEXT-pandoc-onbuild`, `NEXT-ext-pandoc`, `NEXT-ext-pandoc-ci`, `NEXT-ext-pandoc-onbuild` -->
+* Hugo 0.111.3: `0.111.3-pandoc`, `0.111.3-pandoc-ci`, `0.111.3-pandoc-onbuild`, `0.111.3-ext-pandoc`, `0.111.3-ext-pandoc-ci`, `0.111.3-ext-pandoc-onbuild`
 * Hugo 0.107.0: `0.107.0-pandoc`, `0.107.0-pandoc-ci`, `0.107.0-pandoc-onbuild`, `0.107.0-ext-pandoc`, `0.107.0-ext-pandoc-ci`, `0.107.0-ext-pandoc-onbuild`
 * Hugo 0.106.0: `0.106.0-pandoc`, `0.106.0-pandoc-ci`, `0.106.0-pandoc-onbuild`, `0.106.0-ext-pandoc`, `0.106.0-ext-pandoc-ci`, `0.106.0-ext-pandoc-onbuild`
 * Hugo 0.105.0: `0.105.0-pandoc`, `0.105.0-pandoc-ci`, `0.105.0-pandoc-onbuild`, `0.105.0-ext-pandoc`, `0.105.0-ext-pandoc-ci`, `0.105.0-ext-pandoc-onbuild`
@@ -655,6 +659,7 @@ Minimal image based upon [Alpine](https://hub.docker.com/r/_/alpine/) with [Pand
 Image based upon [Debian](https://hub.docker.com/r/_/debian/):
 * Aliases: `debian`, `debian-ci`, `debian-onbuild`, `ext`, `latest-ext`, `ext-debian`, `ext-debian-ci`, `ext-ci`, `ext-debian-onbuild`, `ext-onbuild`
 <!-- * Hugo NEXT: `NEXT-debian`, `NEXT-debian-ci`, `NEXT-debian-onbuild`, `NEXT-ext`, `NEXT-ext-debian`, `NEXT-ext-debian-ci`, `NEXT-ext-ci`, `NEXT-ext-debian-onbuild`, `NEXT-ext-onbuild` -->
+* Hugo 0.111.3: `0.111.3-debian`, `0.111.3-debian-ci`, `0.111.3-debian-onbuild`, `0.111.3-ext`, `0.111.3-ext-debian`, `0.111.3-ext-debian-ci`, `0.111.3-ext-ci`, `0.111.3-ext-debian-onbuild`, `0.111.3-ext-onbuild`
 * Hugo 0.107.0: `0.107.0-debian`, `0.107.0-debian-ci`, `0.107.0-debian-onbuild`, `0.107.0-ext`, `0.107.0-ext-debian`, `0.107.0-ext-debian-ci`, `0.107.0-ext-ci`, `0.107.0-ext-debian-onbuild`, `0.107.0-ext-onbuild`
 * Hugo 0.106.0: `0.106.0-debian`, `0.106.0-debian-ci`, `0.106.0-debian-onbuild`, `0.106.0-ext`, `0.106.0-ext-debian`, `0.106.0-ext-debian-ci`, `0.106.0-ext-ci`, `0.106.0-ext-debian-onbuild`, `0.106.0-ext-onbuild`
 * Hugo 0.105.0: `0.105.0-debian`, `0.105.0-debian-ci`, `0.105.0-debian-onbuild`, `0.105.0-ext`, `0.105.0-ext-debian`, `0.105.0-ext-debian-ci`, `0.105.0-ext-ci`, `0.105.0-ext-debian-onbuild`, `0.105.0-ext-onbuild`
@@ -805,6 +810,7 @@ Image based upon [Debian](https://hub.docker.com/r/_/debian/):
 Image based upon [Ubuntu](https://hub.docker.com/r/_/ubuntu/):
 * Aliases: `ubuntu`, `ubuntu-ci`, `ubuntu-onbuild`, `ext-ubuntu`, `ext-ubuntu-ci`, `ext-ubuntu-onbuild`
 <!-- * Hugo NEXT: `NEXT-ubuntu`, `NEXT-ubuntu-ci`, `NEXT-ubuntu-onbuild`, `NEXT-ext-ubuntu`, `NEXT-ext-ubuntu-ci`, `NEXT-ext-ubuntu-onbuild` -->
+* Hugo 0.111.3: `0.111.3-ubuntu`, `0.111.3-ubuntu-ci`, `0.111.3-ubuntu-onbuild`, `0.111.3-ext-ubuntu`, `0.111.3-ext-ubuntu-ci`, `0.111.3-ext-ubuntu-onbuild`
 * Hugo 0.107.0: `0.107.0-ubuntu`, `0.107.0-ubuntu-ci`, `0.107.0-ubuntu-onbuild`, `0.107.0-ext-ubuntu`, `0.107.0-ext-ubuntu-ci`, `0.107.0-ext-ubuntu-onbuild`
 * Hugo 0.106.0: `0.106.0-ubuntu`, `0.106.0-ubuntu-ci`, `0.106.0-ubuntu-onbuild`, `0.106.0-ext-ubuntu`, `0.106.0-ext-ubuntu-ci`, `0.106.0-ext-ubuntu-onbuild`
 * Hugo 0.105.0: `0.105.0-ubuntu`, `0.105.0-ubuntu-ci`, `0.105.0-ubuntu-onbuild`, `0.105.0-ext-ubuntu`, `0.105.0-ext-ubuntu-ci`, `0.105.0-ext-ubuntu-onbuild`

--- a/src/project.yaml
+++ b/src/project.yaml
@@ -1,5 +1,5 @@
 image: klakegg/hugo
-version: 0.107.0
+version: 0.111.3
 
 platforms:
   - linux/amd64


### PR DESCRIPTION
Hi! :)
I would like to see hugo v0.110.0 in this docker container. I took the last hugo update ([https://github.com/klakegg/docker-hugo/commit/81b3d62dc8c2915931c22d6992840d9d26c49d23](https://github.com/klakegg/docker-hugo/commit/81b3d62dc8c2915931c22d6992840d9d26c49d23)) as a reference for this pull request. I hope this includes all necessary changes.

Because the last pushed version was v0.107.0 I referenced this release in `doc/changelog/0.110.0.md`.